### PR TITLE
Fix examples

### DIFF
--- a/components/form.html
+++ b/components/form.html
@@ -49,20 +49,6 @@
   </div>
 
   <h2>Inline form</h2>
-  <div class="ba br2 b--black-10 shadow-1 pa3">
-    <p class="mt0 f6 fw6 silver">EXAMPLE</p>
-    <form>
-      <div class="mv3 dib">
-        <label class="fw7 f6" for="exampleInputName1">Name</label>
-        <input type="text" class="pa2 mt2 br2 b--black-20 ba f6" id="exampleInputName1" placeholder="Jane Doe">
-      </div>
-      <div class="mv3 dib">
-        <label class="fw7 f6" for="exampleInputEmail2">Email</label>
-        <input type="email" class="pa2 mt2 br2 b--black-20 ba f6" id="exampleInputEmail2" placeholder="jane.doe@example.com">
-      </div>
-      <button type="submit" class="pointer br2 ba b--black-20 bg-white pa2 ml1 mv1 bg-animate hover-bg-light-gray f6">Send invitation</button>
-    </form>
-  </div>
   <div class="ba br2 b--black-10 shadow-1 pa3 mv3">
     <p class="mt0 f6 fw6 silver">EXAMPLE</p>
     <form>

--- a/components/grid.html
+++ b/components/grid.html
@@ -143,7 +143,7 @@
 
   <h2>Example: Container</h2>
   <p>
-    Grid layouts can have a fixed width by using <code class="red bg-washed-red ph1 br2">mw8</code> (max-width: 64rem = 1024px)</li> and <code class="red bg-washed-red ph1 br2">center</code> (to center the container) in the outer wrapping div.
+    Grid layouts can have a fixed width by using <code class="red bg-washed-red ph1 br2">mw8</code> (max-width: 64rem = 1024px) and <code class="red bg-washed-red ph1 br2">center</code> (to center the container) in the outer wrapping div.
   </p>
 
   <p>

--- a/components/grid.html
+++ b/components/grid.html
@@ -141,17 +141,9 @@
 &lt/div&gt
   </pre>
 
-  <h2>Example: Fluid container</h2>
+  <h2>Example: Container</h2>
   <p>
-    Grid layouts can have a fixed width by using any of:
-    <ul>
-      <li class="mv2"><code class="red bg-washed-red ph1 br2">w1</code></li>
-      <li class="mv2"><code class="red bg-washed-red ph1 br2">w2</code></li>
-      <li class="mv2"><code class="red bg-washed-red ph1 br2">w3</code></li>
-      <li class="mv2"><code class="red bg-washed-red ph1 br2">w4</code></li>
-      <li class="mv2"><code class="red bg-washed-red ph1 br2">w5</code></li>
-    </ul>
-    in the outer wrapping div.
+    Grid layouts can have a fixed width by using <code class="red bg-washed-red ph1 br2">mw8</code> (max-width: 64rem = 1024px)</li> and <code class="red bg-washed-red ph1 br2">center</code> (to center the container) in the outer wrapping div.
   </p>
 
   <p>

--- a/components/typography.html
+++ b/components/typography.html
@@ -166,7 +166,6 @@ You can use the mark tag to &ltmark class="bg-light-yellow ph1"&gthighlight&lt/m
     <p class="tr">Right aligned text.</p>
     <p class="nowrap">No wrap text.</p>
     <pre class="br2 ba b--black-10 bg-light-gray pv3 pl3 pre w-100">
-&ltp class="mt0 f6 fw6 silver"&gtEXAMPLE&lt/p&gt
 &ltp class="tl"&gtLeft aligned text.&lt/p&gt
 &ltp class="tc"&gtCenter aligned text.&lt/p&gt
 &ltp class="tr"&gtRight aligned text.&lt/p&gt


### PR DESCRIPTION
- remove an wrong code line in typography example
- indicate `mw8` instead of `w1~w6` (this width helpers are too smalls for containers)
- leave just one inline form example